### PR TITLE
Fixed fatal error: 'cl.h' file not found on MacOSX

### DIFF
--- a/cl/cl.go
+++ b/cl/cl.go
@@ -16,7 +16,11 @@ in the Go standard packages.
 */
 package cl
 
+// #ifdef __APPLE__
+// #include "OpenCL/opencl.h"
+// #else
 // #include "cl.h"
+// #endif
 // #cgo darwin LDFLAGS: -framework OpenCL
 import "C"
 import "errors"

--- a/cl/context.go
+++ b/cl/context.go
@@ -1,7 +1,11 @@
 package cl
 
 // #include <stdlib.h>
+// #ifdef __APPLE__
+// #include "OpenCL/opencl.h"
+// #else
 // #include "cl.h"
+// #endif
 import "C"
 
 import (

--- a/cl/device.go
+++ b/cl/device.go
@@ -1,6 +1,10 @@
 package cl
 
+// #ifdef __APPLE__
+// #include "OpenCL/opencl.h"
+// #else
 // #include "cl.h"
+// #endif
 import "C"
 
 import (

--- a/cl/device12.go
+++ b/cl/device12.go
@@ -2,7 +2,11 @@
 
 package cl
 
+// #ifdef __APPLE__
+// #include "OpenCL/opencl.h"
+// #else
 // #include "cl.h"
+// #endif
 import "C"
 import "unsafe"
 

--- a/cl/image.go
+++ b/cl/image.go
@@ -2,7 +2,11 @@
 
 package cl
 
+// #ifdef __APPLE__
+// #include "OpenCL/opencl.h"
+// #else
 // #include "cl.h"
+// #endif
 import "C"
 import (
 	"image"

--- a/cl/kernel.go
+++ b/cl/kernel.go
@@ -1,6 +1,10 @@
 package cl
 
+// #ifdef __APPLE__
+// #include "OpenCL/opencl.h"
+// #else
 // #include "cl.h"
+// #endif
 import "C"
 
 import (

--- a/cl/kernel12.go
+++ b/cl/kernel12.go
@@ -2,7 +2,11 @@
 
 package cl
 
-// #import "cl.h"
+// #ifdef __APPLE__
+// #include "OpenCL/opencl.h"
+// #else
+// #include "cl.h"
+// #endif
 import "C"
 import "unsafe"
 

--- a/cl/platform.go
+++ b/cl/platform.go
@@ -1,6 +1,10 @@
 package cl
 
+// #ifdef __APPLE__
+// #include "OpenCL/opencl.h"
+// #else
 // #include "cl.h"
+// #endif
 import "C"
 
 import (

--- a/cl/program.go
+++ b/cl/program.go
@@ -1,7 +1,11 @@
 package cl
 
 // #include <stdlib.h>
+// #ifdef __APPLE__
+// #include "OpenCL/opencl.h"
+// #else
 // #include "cl.h"
+// #endif
 import "C"
 
 import (

--- a/cl/queue.go
+++ b/cl/queue.go
@@ -1,6 +1,10 @@
 package cl
 
+// #ifdef __APPLE__
+// #include "OpenCL/opencl.h"
+// #else
 // #include "cl.h"
+// #endif
 import "C"
 
 import (

--- a/cl/queue12.go
+++ b/cl/queue12.go
@@ -2,7 +2,11 @@
 
 package cl
 
+// #ifdef __APPLE__
+// #include "OpenCL/opencl.h"
+// #else
 // #include "cl.h"
+// #endif
 import "C"
 import
 

--- a/cl/types.go
+++ b/cl/types.go
@@ -1,6 +1,10 @@
 package cl
 
+// #ifdef __APPLE__
+// #include "OpenCL/opencl.h"
+// #else
 // #include "cl.h"
+// #endif
 import "C"
 
 import (

--- a/cl/types12.go
+++ b/cl/types12.go
@@ -2,7 +2,11 @@
 
 package cl
 
+// #ifdef __APPLE__
+// #include "OpenCL/opencl.h"
+// #else
 // #include "cl.h"
+// #endif
 import "C"
 
 const (

--- a/cl/types_darwin.go
+++ b/cl/types_darwin.go
@@ -1,6 +1,10 @@
 package cl
 
+// #ifdef __APPLE__
+// #include "OpenCL/opencl.h"
+// #else
 // #include "cl.h"
+// #endif
 import "C"
 
 // Extension: cl_APPLE_fixed_alpha_channel_orders


### PR DESCRIPTION
I'm not the author of this changeset, but I had this problem, saw this patch in this fork, and thought I'd make a pull request to add it upstream.
