### PR TITLE
OpenCL strings are NUL-terminated but Go strings aren't

### DIFF
--- a/cl/device.go
+++ b/cl/device.go
@@ -126,7 +126,10 @@ func (d *Device) getInfoString(param C.cl_device_info, panicOnError bool) (strin
 		}
 		return "", toError(err)
 	}
-	return C.GoStringN((*C.char)(unsafe.Pointer(&strC)), C.int(strN)), nil
+
+	// OpenCL strings are NUL-terminated, and the terminator is included in strN
+	// Go strings aren't NUL-terminated, so subtract 1 from the length
+	return C.GoStringN((*C.char)(unsafe.Pointer(&strC)), C.int(strN-1)), nil
 }
 
 func (d *Device) getInfoUint(param C.cl_device_info, panicOnError bool) (uint, error) {

--- a/cl/platform.go
+++ b/cl/platform.go
@@ -3,9 +3,7 @@ package cl
 // #include "cl.h"
 import "C"
 
-import (
-	"unsafe"
-)
+import "unsafe"
 
 const maxPlatforms = 32
 
@@ -37,7 +35,7 @@ func (p *Platform) getInfoString(param C.cl_platform_info) (string, error) {
 	if err := C.clGetPlatformInfo(p.id, param, 2048, unsafe.Pointer(&strC[0]), &strN); err != C.CL_SUCCESS {
 		return "", toError(err)
 	}
-	return string(strC[:strN]), nil
+	return string(strC[:(strN - 1)]), nil
 }
 
 func (p *Platform) Name() string {


### PR DESCRIPTION
OpenCL string-returning functions include NUL terminators, included in the length of the returned string. Go strings shouldn't contain these terminators, but at present, they do. This commit fixes that and adds tests to that effect.
